### PR TITLE
Remove warning on querySingle variable

### DIFF
--- a/gotty-client.go
+++ b/gotty-client.go
@@ -157,7 +157,7 @@ func (c *Client) Connect() error {
 	if err != nil {
 		return err
 	}
-	var querySingle querySingleType = querySingleType{
+	querySingle := querySingleType{
 		Arguments: "?" + query.Encode(),
 		AuthToken: authToken,
 	}


### PR DESCRIPTION
should omit type querySingleType from declaration of var querySingle; it will be inferred from the right-hand side