### PR TITLE
support for gotty v2.0 and ws-origin

### DIFF
--- a/cmd/gotty-client/main.go
+++ b/cmd/gotty-client/main.go
@@ -26,7 +26,8 @@ func main() {
 	app.ArgsUsage = "GOTTY_URL"
 	app.BashComplete = func(c *cli.Context) {
 		for _, command := range []string{
-			"--debug", "--skip-tls-verify", "--use-proxy-from-env", "--help",
+			"--debug", "--skip-tls-verify", "--use-proxy-from-env",
+			"--v2", "--detach-keys", "--help",
 			"--generate-bash-completion", "--version",
 			"http://user:pass@host:1234/path/\\\\?arg=abcdef\\\\&arg=ghijkl",
 			"https://user:pass@host:1234/path/\\\\?arg=abcdef\\\\&arg=ghijkl",
@@ -56,6 +57,11 @@ func main() {
 			Name:  "detach-keys",
 			Usage: "Key sequence for detaching gotty-client",
 			Value: "ctrl-p,ctrl-q",
+		},
+		cli.BoolFlag{
+			Name:   "v2",
+			Usage:  "For Gotty 2.0",
+			EnvVar: "GOTTY_CLIENT_GOTTY2",
 		},
 	}
 
@@ -90,6 +96,10 @@ func action(c *cli.Context) error {
 
 	if c.Bool("use-proxy-from-env") {
 		client.UseProxyFromEnv = true
+	}
+
+	if c.Bool("v2") {
+		client.V2 = true
 	}
 
 	if detachKey := c.String("detach-keys"); detachKey != "" {

--- a/cmd/gotty-client/main.go
+++ b/cmd/gotty-client/main.go
@@ -27,7 +27,7 @@ func main() {
 	app.BashComplete = func(c *cli.Context) {
 		for _, command := range []string{
 			"--debug", "--skip-tls-verify", "--use-proxy-from-env",
-			"--v2", "--detach-keys", "--help",
+			"--v2", "--detach-keys", "--ws-origin", "--help",
 			"--generate-bash-completion", "--version",
 			"http://user:pass@host:1234/path/\\\\?arg=abcdef\\\\&arg=ghijkl",
 			"https://user:pass@host:1234/path/\\\\?arg=abcdef\\\\&arg=ghijkl",
@@ -62,6 +62,11 @@ func main() {
 			Name:   "v2",
 			Usage:  "For Gotty 2.0",
 			EnvVar: "GOTTY_CLIENT_GOTTY2",
+		},
+		cli.StringFlag{
+			Name:   "ws-origin, w",
+			Usage:  "WebSocket Origin URL",
+			EnvVar: "GOTTY_CLIENT_WS_ORIGIN",
 		},
 	}
 
@@ -100,6 +105,10 @@ func action(c *cli.Context) error {
 
 	if c.Bool("v2") {
 		client.V2 = true
+	}
+
+	if wsOrigin := c.String("ws-origin"); wsOrigin != "" {
+		client.WSOrigin = wsOrigin
 	}
 
 	if detachKey := c.String("detach-keys"); detachKey != "" {

--- a/gotty-client.go
+++ b/gotty-client.go
@@ -134,6 +134,7 @@ type Client struct {
 	EscapeKeys      []byte
 	V2              bool
 	message         *gottyMessageType
+	WSOrigin        string
 }
 
 type querySingleType struct {
@@ -206,6 +207,9 @@ func (c *Client) Connect() error {
 	target, header, err := GetWebsocketURL(c.URL)
 	if err != nil {
 		return err
+	}
+	if c.WSOrigin != "" {
+		header.Add("Origin", c.WSOrigin)
 	}
 	logrus.Debugf("Connecting to websocket: %q", target.String())
 	if c.SkipTLSVerify {


### PR DESCRIPTION
This pull request adds support for gotty v2.0 and ws-origin

* Add --v2 option to support gotty v2.0 (some message types of gotty have changed)

* Add --ws-origin option to allow cross-origin requests to WS endpoint (ws-origin option added to gotty)