### PR TITLE
Add test to check if escapeKeys is empty

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -13,7 +13,6 @@
 // CHANGES:
 // - update package
 
-
 package gottyclient
 
 import (
@@ -49,6 +48,10 @@ func NewEscapeProxy(r io.Reader, escapeKeys []byte) io.Reader {
 
 func (r *escapeProxy) Read(buf []byte) (int, error) {
 	nr, err := r.r.Read(buf)
+
+	if len(r.escapeKeys) == 0 {
+		return nr, err
+	}
 
 	preserve := func() {
 		// this preserves the original key presses in the passed in buffer


### PR DESCRIPTION
Update proxy.go to resolve scaleway/scaleway-cli#497
I did not noticed that moby/pkg/term is not used when using EscapeProxy :roll_eyes: 

Signed-off-by: Patrik Cyvoct <patrik@ptrk.io>