### PR TITLE
fix escaped basic token

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,74 @@
+env:
+  - GO111MODULE=on
+  - GOPROXY=https://proxy.golang.org
+before:
+  hooks:
+    - go mod download
+builds:
+  -
+    main: ./cmd/gotty-client
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - 386
+      - amd64
+      - arm
+      - arm64
+    ignore:
+      -
+        goos: darwin
+        goarch: 386
+    flags:
+      - "-a"
+    ldflags:
+      - '-extldflags "-static"'
+checksum:
+  name_template: '{{.ProjectName}}_checksums.txt'
+changelog:
+  sort: asc
+  filters:
+    exclude:
+    - '^docs:'
+    - '^test:'
+    - Merge pull request
+    - Merge branch
+archives:
+  -
+    name_template: '{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    replacements:
+      darwin: Darwin
+      linux: Linux
+      windows: Windows
+      386: i386
+      amd64: x86_64
+    format_overrides:
+    -
+      goos: windows
+      format: zip
+    wrap_in_directory: true
+brews:
+  -
+    name: gotty-client
+#    github:
+#      owner: moul
+#      name: homebrew-moul
+    commit_author:
+      name: moul-bot
+      email: "bot@moul.io"
+    homepage: https://github.com/moul/gotty-client
+    description: "gotty-client"
+nfpms:
+  -
+    file_name_template: '{{ .ProjectName }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+    homepage:  https://github.com/moul/gotty-client
+    description: "gotty-client"
+    maintainer: "Manfred Touron <https://manfred.life>"
+    license: "Apache-2.0 OR MIT"
+    vendor: moul
+    formats:
+      - deb
+      - rpm

--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@
                                                               +----------------+
                +--------------+                +---------+--->|   /bin/bash    |
                |              |                |         |    +----------------+
-           +-->|   Browser    |--+             |         |                      
-+-------+  |   |              |  |             |         |                      
+           +-->|   Browser    |--+             |         |
++-------+  |   |              |  |             |         |
 |       |  |   +--------------+  |             |         |    +----------------+
 |  Bob  |--+                     +-websocket-->|  Gotty  |--->| emacs /var/www |
 |       |  |    XXXXXXXXXXXXXX   |             |         |    +----------------+
-+-------+  |   X              X  |             |         |                      
-           +-->X gotty-client X--+             |         |                      
++-------+  |   X              X  |             |         |
+           +-->X gotty-client X--+             |         |
                X              X                |         |    +----------------+
                 XXXXXXXXXXXXXX                 +---------+--->|  tmux attach   |
                                                               +----------------+
@@ -83,11 +83,15 @@ GLOBAL OPTIONS:
 
 ## Install
 
-Install latest version using Golang (recommended)
+Install latest version using Golang (recommended):
 
-```console
-$ go get github.com/moul/gotty-client/cmd/gotty-client
+```bash
+git clone https://github.com/moul/gotty-client
+cd gotty-client
+make install # or `go install ./cmd/gotty-client`
 ```
+
+_PS: I don't know why, but `go get github.com/moul/gotty-client/cmd/gotty-client` is not stable everywhere_
 
 ---
 

--- a/gotty-client.go
+++ b/gotty-client.go
@@ -81,8 +81,12 @@ func GetAuthTokenURL(httpURL string) (*url.URL, *http.Header, error) {
 
 	target.Path = strings.TrimLeft(target.Path+"auth_token.js", "/")
 
+	user, err := url.PathUnescape(target.User.String())
+	if err != nil {
+		user = target.User.String()
+	}
 	if target.User != nil {
-		header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(target.User.String())))
+		header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(user)))
 		target.User = nil
 	}
 


### PR DESCRIPTION
`target.User.String()` gives Percent-encoded string.

It is not suitable when making basic token which is base64 encoded.