### PR TITLE
[#107] fix: escaped basic token on /ws

### DIFF
--- a/gotty-client.go
+++ b/gotty-client.go
@@ -118,8 +118,12 @@ func GetWebsocketURL(httpURL string) (*url.URL, *http.Header, error) {
 
 	target.Path = strings.TrimLeft(target.Path+"ws", "/")
 
+	user, err := url.PathUnescape(target.User.String())
+	if err != nil {
+		user = target.User.String()
+	}
 	if target.User != nil {
-		header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(target.User.String())))
+		header.Add("Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(user)))
 		target.User = nil
 	}
 


### PR DESCRIPTION
<!--
Thank you for your contribution to this repo!

Before submitting a pull request, please check the following:
- reference any related issue, PR, link
- use the "WIP" title prefix if you need help or more time to finish your PR

you can remove this markdown comment
-->

details at https://github.com/moul/gotty-client/issues/107